### PR TITLE
Move key logging to a -v flag, add verbose ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * Node.JS of any recent vintage
 * SSH keys stored in ``~/.ssh/`` and named after the AWS keypairs
 * `~/.aws/config` file with credentials ([details](https://github.com/aws/aws-cli#getting-started))
-  * For a good experiance, include the region
+  * For a good experience, include the region
 
 ## Installation and Updating
 `npm install -g sugar-ssh`


### PR DESCRIPTION
Hides by default most of the debug logging about ssh host keys. Passing
`-v` to sugar shows this logging again, and passes `-v` to ssh for
extra fun.