### PR TITLE
Add interactive flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-release": "^0.12.0",
     "ini": "^1.2.1",
     "nomnom": "^1.8.1",
+    "readline-sync": "^1.2.19",
     "ssh-fingerprint": "0.0.1"
   },
   "devDependencies": {

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -185,7 +185,7 @@ function getInstances(ec2) {
 
 function listInstances(instances, printIndex) {
   instances.forEach(function (instance, index) {
-    let prefix = printIndex ? `${index + ': '}` : '';
+    let prefix = printIndex ? `${index}: ` : '';
 
     console.log([
       prefix + instance.InstanceId,

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -183,10 +183,12 @@ function getInstances(ec2) {
   });
 }
 
-function listInstances(instances) {
+function listInstances(instances, printIndex) {
   instances.forEach(function (instance, index) {
+    let prefix = printIndex ? `${index + ': '}` : '';
+
     console.log([
-      `${index}: ${instance.InstanceId}`,
+      prefix + instance.InstanceId,
       instance.Name,
       instance.PublicDnsName || instance.PublicIpAddress
     ].join('\t'));
@@ -201,7 +203,7 @@ function selectInstance(args, filter, instances) {
 
     if (instances.some(instance => instance.Name !== baseName)) {
       console.error(filter, 'matches multiple different instances.');
-      listInstances(instances);
+      listInstances(instances, args.interactive);
     }
 
     if (args.interactive) {

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -404,7 +404,7 @@ function connect(cmdOpts) {
       function runSSH() {
         let flair;
         if (instance.oneOf > 1) {
-          flair = `(one of ${instance.oneOf} ${instance.Name} instances)`;
+          flair = `(one of ${instance.oneOf} instances matching "${filter}")`;
         } else {
           flair = `(the only ${instance.Name} instance)`;
         }

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -85,7 +85,7 @@ addCommonSSHOpts(
     .option('interactive', {
       abbr: 'n',
       flag: true,
-      help: 'Prompt the user to select a specific instance'
+      help: 'Prompt to select a specific instance if more than one matches.'
     })
     .callback(connect)
     .help("Connect to a matching instance via ssh.")


### PR DESCRIPTION
```
$ ./bin/sugar ssh 'Foo' -n                                                           
foo matches multiple different instances.
0: i-aaaaa   foo 2       ...us-west-2.compute.amazonaws.com
1: i-bbbbb   foo 3       ...us-west-2.compute.amazonaws.com
2: i-ccccc   foo 1       ...us-west-2.compute.amazonaws.com
Select an instance: -1
Select an instance: 2
Connecting to i-ccccc (one of 3 instances matching "foo")
```
